### PR TITLE
Remove circular dependency

### DIFF
--- a/projects/cps-mdoc-viewer/src/lib/components/markdown-viewer/markdown-viewer.component.spec.ts
+++ b/projects/cps-mdoc-viewer/src/lib/components/markdown-viewer/markdown-viewer.component.spec.ts
@@ -24,7 +24,7 @@ import { MarkdownResourceService } from '../../services/markdown-resource.servic
 import { MarkdownModule } from 'ngx-markdown';
 import { Title } from '@angular/platform-browser';
 import { CpsDividerComponent } from 'cps-ui-kit';
-import { CONFIG_INJECTION_TOKEN } from '../../lib.provider';
+import { CONFIG_INJECTION_TOKEN } from '../../config/config';
 
 describe('MarkdownViewerComponent', () => {
   globalThis.window.scrollTo = jest.fn();

--- a/projects/cps-mdoc-viewer/src/lib/components/markdown-viewer/markdown-viewer.component.ts
+++ b/projects/cps-mdoc-viewer/src/lib/components/markdown-viewer/markdown-viewer.component.ts
@@ -26,7 +26,7 @@ import { CpsDividerComponent } from 'cps-ui-kit';
 import {
   CONFIG_INJECTION_TOKEN,
   CPSMDocViewerConfig
-} from '../../lib.provider';
+} from '../../config/config';
 
 @Component({
   selector: 'app-markdown-viewer',

--- a/projects/cps-mdoc-viewer/src/lib/components/navbar/navbar.component.spec.ts
+++ b/projects/cps-mdoc-viewer/src/lib/components/navbar/navbar.component.spec.ts
@@ -28,7 +28,7 @@ import { of } from 'rxjs';
 import { ActivatedRoute } from '@angular/router';
 import { DirectoryToolbarInfo } from '../../models/directory-toolbar-info.interface';
 import { By } from '@angular/platform-browser';
-import { CONFIG_INJECTION_TOKEN } from '../../lib.provider';
+import { CONFIG_INJECTION_TOKEN } from '../../config/config';
 
 describe('NavbarComponent', () => {
   let component: NavbarComponent;

--- a/projects/cps-mdoc-viewer/src/lib/components/navbar/navbar.component.ts
+++ b/projects/cps-mdoc-viewer/src/lib/components/navbar/navbar.component.ts
@@ -31,7 +31,7 @@ import { CpsIconComponent } from 'cps-ui-kit';
 import {
   CONFIG_INJECTION_TOKEN,
   CPSMDocViewerConfig
-} from '../../lib.provider';
+} from '../../config/config';
 
 @Component({
   selector: 'navbar',

--- a/projects/cps-mdoc-viewer/src/lib/config/config.ts
+++ b/projects/cps-mdoc-viewer/src/lib/config/config.ts
@@ -14,10 +14,15 @@
  * limitations under the License.
  */
 
-/*
- * Public API Surface of cps-mdoc-viewer
- */
+import { InjectionToken } from '@angular/core';
 
-export { provideCPSMDocViewer } from './lib/lib.provider';
-export { CPSMDocViewerConfig } from './lib/config/config';
-export * from './lib/components/cps-mdoc-viewer/cps-mdoc-viewer.component';
+export const CONFIG_INJECTION_TOKEN = new InjectionToken<CPSMDocViewerConfig>(
+  'CPSMDocViewerConfig'
+);
+
+export interface CPSMDocViewerConfig {
+  headerTitle: string;
+  pageTitle: string;
+  logo?: string;
+  markdownFilesLocation: string;
+}

--- a/projects/cps-mdoc-viewer/src/lib/config/routes.ts
+++ b/projects/cps-mdoc-viewer/src/lib/config/routes.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2024 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Observable } from 'rxjs';
+import { MarkdownFile } from '../models/categories.interface';
+import { inject } from '@angular/core';
+import { firstDirectoryGuard } from '../guards/first-directory.guard';
+import { MarkdownViewerComponent } from '../components/markdown-viewer/markdown-viewer.component';
+import { MarkdownResourceService } from '../services/markdown-resource.service';
+import { ResolveFn, ActivatedRouteSnapshot, Routes } from '@angular/router';
+
+const markdownFilesResolver: ResolveFn<Observable<MarkdownFile[]>> = (
+  route: ActivatedRouteSnapshot
+) => {
+  const markdownResourceService = inject(MarkdownResourceService);
+  const selectedDirectory = route.paramMap.get('directory') ?? '';
+  return markdownResourceService.getMarkdownFiles(selectedDirectory);
+};
+
+export const routes: Routes = [':directory', '**'].map((path) => ({
+  path,
+  component: MarkdownViewerComponent,
+  resolve: { markdownFiles: markdownFilesResolver },
+  canActivate: [firstDirectoryGuard]
+}));

--- a/projects/cps-mdoc-viewer/src/lib/lib.provider.ts
+++ b/projects/cps-mdoc-viewer/src/lib/lib.provider.ts
@@ -16,35 +16,14 @@
 
 import {
   EnvironmentProviders,
-  InjectionToken,
   SecurityContext,
   makeEnvironmentProviders
 } from '@angular/core';
 import { provideRouter } from '@angular/router';
-import { ActivatedRouteSnapshot, ResolveFn, Routes } from '@angular/router';
-import { Observable } from 'rxjs';
-import { MarkdownFile } from './models/categories.interface';
-import { inject } from '@angular/core';
-import { firstDirectoryGuard } from './guards/first-directory.guard';
-import { MarkdownViewerComponent } from './components/markdown-viewer/markdown-viewer.component';
-import { MarkdownResourceService } from './services/markdown-resource.service';
 import { MARKED_OPTIONS, MarkedOptions, provideMarkdown } from 'ngx-markdown';
 import { HttpClient, provideHttpClient } from '@angular/common/http';
-
-const markdownFilesResolver: ResolveFn<Observable<MarkdownFile[]>> = (
-  route: ActivatedRouteSnapshot
-) => {
-  const markdownResourceService = inject(MarkdownResourceService);
-  const selectedDirectory = route.paramMap.get('directory') ?? '';
-  return markdownResourceService.getMarkdownFiles(selectedDirectory);
-};
-
-const routes: Routes = [':directory', '**'].map((path) => ({
-  path,
-  component: MarkdownViewerComponent,
-  resolve: { markdownFiles: markdownFilesResolver },
-  canActivate: [firstDirectoryGuard]
-}));
+import { routes } from './config/routes';
+import { CONFIG_INJECTION_TOKEN, CPSMDocViewerConfig } from './config/config';
 
 function markedOptionsFactory(): MarkedOptions {
   return {
@@ -59,17 +38,6 @@ function markedOptionsFactory(): MarkedOptions {
       postprocess: (html: string) => html
     }
   };
-}
-
-export const CONFIG_INJECTION_TOKEN = new InjectionToken<CPSMDocViewerConfig>(
-  'CPSMDocViewerConfig'
-);
-
-export interface CPSMDocViewerConfig {
-  headerTitle: string;
-  pageTitle: string;
-  logo?: string;
-  markdownFilesLocation: string;
 }
 
 export const provideCPSMDocViewer = (

--- a/projects/cps-mdoc-viewer/src/lib/services/categories-data.service.spec.ts
+++ b/projects/cps-mdoc-viewer/src/lib/services/categories-data.service.spec.ts
@@ -22,7 +22,7 @@ import {
 
 import { CategoriesDataService } from './categories-data.service';
 import { Category } from '../models/categories.interface';
-import { CONFIG_INJECTION_TOKEN } from '../lib.provider';
+import { CONFIG_INJECTION_TOKEN } from '../config/config';
 
 describe('CategoriesDataService', () => {
   let service: CategoriesDataService;

--- a/projects/cps-mdoc-viewer/src/lib/services/categories-data.service.ts
+++ b/projects/cps-mdoc-viewer/src/lib/services/categories-data.service.ts
@@ -18,7 +18,7 @@ import { HttpClient } from '@angular/common/http';
 import { Inject, Injectable } from '@angular/core';
 import { Observable, map, shareReplay } from 'rxjs';
 import { Category } from '../models/categories.interface';
-import { CONFIG_INJECTION_TOKEN, CPSMDocViewerConfig } from '../lib.provider';
+import { CONFIG_INJECTION_TOKEN, CPSMDocViewerConfig } from '../config/config';
 
 @Injectable({
   providedIn: 'root'

--- a/projects/example-app/jest.config.js
+++ b/projects/example-app/jest.config.js
@@ -1,5 +1,5 @@
 module.exports = {
   moduleNameMapper: {
-    '^cps-mdoc-viewer$': '<rootDir>/projects/cps-mdoc-viewer/src/public-api.ts'
+    '^cps-mdoc-viewer$': '<rootDir>/dist/cps-mdoc-viewer/fesm2022/cps-mdoc-viewer.mjs'
   }
 };

--- a/projects/example-app/jest.config.js
+++ b/projects/example-app/jest.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   moduleNameMapper: {
-    '^cps-mdoc-viewer$': '<rootDir>/dist/cps-mdoc-viewer/fesm2022/cps-mdoc-viewer.mjs'
+    '^cps-mdoc-viewer$':
+      '<rootDir>/dist/cps-mdoc-viewer/fesm2022/cps-mdoc-viewer.mjs'
   }
 };


### PR DESCRIPTION
There was a circular dependency (`lib.provider.ts` -> `markdown-viewer.component.ts` -> `lib.provider.ts`) this caused `jest` test in the consumer app to fail. Example app in this repo didn't catch it, as it was not importing built version, I changed it to use built version.