### PR TITLE
Move animations provider to library

### DIFF
--- a/projects/cps-mdoc-viewer/src/lib/lib.provider.ts
+++ b/projects/cps-mdoc-viewer/src/lib/lib.provider.ts
@@ -24,6 +24,7 @@ import { MARKED_OPTIONS, MarkedOptions, provideMarkdown } from 'ngx-markdown';
 import { HttpClient, provideHttpClient } from '@angular/common/http';
 import { routes } from './config/routes';
 import { CONFIG_INJECTION_TOKEN, CPSMDocViewerConfig } from './config/config';
+import { provideAnimations } from '@angular/platform-browser/animations';
 
 function markedOptionsFactory(): MarkedOptions {
   return {
@@ -57,6 +58,7 @@ export const provideCPSMDocViewer = (
     {
       provide: CONFIG_INJECTION_TOKEN,
       useValue: config
-    }
+    },
+    provideAnimations()
   ]);
 };

--- a/projects/example-app/src/app/app.config.ts
+++ b/projects/example-app/src/app/app.config.ts
@@ -16,11 +16,9 @@
 
 import { ApplicationConfig } from '@angular/core';
 import { provideCPSMDocViewer } from 'cps-mdoc-viewer';
-import { provideAnimations } from '@angular/platform-browser/animations';
 
 export const appConfig: ApplicationConfig = {
   providers: [
-    provideAnimations(),
     provideCPSMDocViewer({
       headerTitle: 'CPS MDoc Viewer',
       pageTitle: 'Example App of the CPS MDoc Viewer library',


### PR DESCRIPTION
Library users might forget to provide it, it is now required for `cps-table` support.