### PR TITLE
Roll back to v0.0.13, remove registry & use npm@11 in publish step

### DIFF
--- a/.github/workflows/cps-mdoc-viewer-publish.yml
+++ b/.github/workflows/cps-mdoc-viewer-publish.yml
@@ -66,7 +66,6 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: 22.x
-          registry-url: 'https://registry.npmjs.org'
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/cps-mdoc-viewer-publish.yml
+++ b/.github/workflows/cps-mdoc-viewer-publish.yml
@@ -28,7 +28,6 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: 22.x
-          registry-url: 'https://registry.npmjs.org'
 
       - name: Bump version
         id: bump
@@ -67,6 +66,9 @@ jobs:
         with:
           node-version: 22.x
           cache: 'npm'
+
+      - name: Use latest npm 11 (required by npmjs.com OIDC)
+        run: npm install -g npm@11
 
       - name: Install dependencies
         run: npm ci

--- a/projects/cps-mdoc-viewer/package.json
+++ b/projects/cps-mdoc-viewer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cps-mdoc-viewer",
-  "version": "0.0.14",
+  "version": "0.0.13",
   "peerDependencies": {
     "@angular/common": "^21.2.10",
     "@angular/core": "^21.2.10",


### PR DESCRIPTION
Latest published version is v0.0.12, so I rolled back to `v0.0.13`. It also seems that registry needs to be removed for OIDC to work properly (plus use npm@11 in the publish step).