### PR TITLE
Use setup-node@v6 & Node v24 for trusted publishing

### DIFF
--- a/.github/workflows/cps-mdoc-viewer-publish.yml
+++ b/.github/workflows/cps-mdoc-viewer-publish.yml
@@ -79,4 +79,4 @@ jobs:
 
       - name: Publish to NPM registry
         working-directory: dist/cps-mdoc-viewer
-        run: npm publish
+        run: NODE_AUTH_TOKEN="" npm publish

--- a/.github/workflows/cps-mdoc-viewer-publish.yml
+++ b/.github/workflows/cps-mdoc-viewer-publish.yml
@@ -54,21 +54,18 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Fetch latest commits
         run: git pull origin master
 
-      - name: Use Node.js v22.x
-        uses: actions/setup-node@v5
+      - name: Use Node.js v24.x
+        uses: actions/setup-node@v6
         with:
-          node-version: 22.x
+          node-version: 24.x
           registry-url: 'https://registry.npmjs.org'
-
-      - name: Use latest npm 11 (required by npmjs.com OIDC)
-        run: npm install -g npm@11
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/cps-mdoc-viewer-publish.yml
+++ b/.github/workflows/cps-mdoc-viewer-publish.yml
@@ -65,7 +65,7 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: 22.x
-          cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Use latest npm 11 (required by npmjs.com OIDC)
         run: npm install -g npm@11


### PR DESCRIPTION
Also added `NODE_AUTH_TOKEN` reset as described in https://github.com/actions/setup-node/issues/1440